### PR TITLE
Support `RangeBounds` for `T: Comparable`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - rust: 1.6.0 # MSRV
+          - rust: 1.28.0 # MSRV
           - rust: stable
           - rust: beta
           - rust: nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "equivalent"
-version = "1.0.1"
-rust-version = "1.6"
+version = "1.1.0"
+rust-version = "1.28"
 license = "Apache-2.0 OR MIT"
 description = "Traits for key comparison in maps."
 repository = "https://github.com/cuviper/equivalent"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,9 +57,10 @@
 //!     assert_eq!(q2.compare(&key), Ordering::Less);
 //!     assert_eq!(q3.compare(&key), Ordering::Greater);
 //!
-//!     // You cannot do this with the `RangeBounds::contains` method.
-//!     // assert!((q1..q3).contains(key));
-//!     // But you can do this with the `ComparableRangeBounds::compare_contains` method.
+//!     // You cannot use `Comparable` with the `RangeBounds::contains` method:
+//!     // assert!((q1..q3).contains(&key));
+//!
+//!     // But you can use the `ComparableRangeBounds::compare_contains` method:
 //!     assert!((q1..q3).compare_contains(&key));
 //! }
 //! ```
@@ -143,9 +144,9 @@ pub trait ComparableRangeBounds<Q: ?Sized>: RangeBounds<Q> {
     }
 }
 
-impl<R, T> ComparableRangeBounds<T> for R
+impl<R, Q> ComparableRangeBounds<Q> for R
 where
-    R: ?Sized + RangeBounds<T>,
-    T: ?Sized,
+    R: ?Sized + RangeBounds<Q>,
+    Q: ?Sized,
 {
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,10 +86,10 @@ pub trait Equivalent<K: ?Sized> {
     fn equivalent(&self, key: &K) -> bool;
 }
 
-impl<Q: ?Sized, K: ?Sized> Equivalent<K> for Q
+impl<Q, K> Equivalent<K> for Q
 where
-    Q: Eq,
-    K: Borrow<Q>,
+    Q: ?Sized + Eq,
+    K: ?Sized + Borrow<Q>,
 {
     #[inline]
     fn equivalent(&self, key: &K) -> bool {
@@ -108,10 +108,10 @@ pub trait Comparable<K: ?Sized>: Equivalent<K> {
     fn compare(&self, key: &K) -> Ordering;
 }
 
-impl<Q: ?Sized, K: ?Sized> Comparable<K> for Q
+impl<Q, K> Comparable<K> for Q
 where
-    Q: Ord,
-    K: Borrow<Q>,
+    Q: ?Sized + Ord,
+    K: ?Sized + Borrow<Q>,
 {
     #[inline]
     fn compare(&self, key: &K) -> Ordering {


### PR DESCRIPTION
Hi, this PR adds functionality like `RangeBounds::contains` for `T: Comparable`.